### PR TITLE
Adds the update-tracker command to Deluge console (repo, stable, and dev)

### DIFF
--- a/scripts/deluge.UpdateTracker.py
+++ b/scripts/deluge.UpdateTracker.py
@@ -1,0 +1,65 @@
+# from https://github.com/s0undt3ch/Deluge/blob/master/deluge/ui/console/commands/update-tracker.py
+# update-tracker.py
+#
+# Copyright (C) 2008-2009 Ido Abramovich <ido.deluge@gmail.com>
+# Copyright (C) 2009 Andrew Resch <andrewresch@gmail.com>
+#
+# Deluge is free software.
+#
+# You may redistribute it and/or modify it under the terms of the
+# GNU General Public License, as published by the Free Software
+# Foundation; either version 3 of the License, or (at your option)
+# any later version.
+#
+# deluge is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with deluge.    If not, write to:
+# 	The Free Software Foundation, Inc.,
+# 	51 Franklin Street, Fifth Floor
+# 	Boston, MA  02110-1301, USA.
+#
+#    In addition, as a special exception, the copyright holders give
+#    permission to link the code of portions of this program with the OpenSSL
+#    library.
+#    You must obey the GNU General Public License in all respects for all of
+#    the code used other than OpenSSL. If you modify file(s) with this
+#    exception, you may extend this exception to your version of the file(s),
+#    but you are not obligated to do so. If you do not wish to do so, delete
+#    this exception statement from your version. If you delete this exception
+#    statement from all source files in the program, then also delete it here.
+#
+#
+from deluge.ui.console.main import BaseCommand
+import deluge.ui.console.colors as colors
+from deluge.ui.client import client
+import deluge.component as component
+
+from optparse import make_option
+
+
+class Command(BaseCommand):
+    """Update tracker for torrent(s)"""
+    usage = "Usage: update-tracker [ * | <torrent-id> [<torrent-id> ...] ]"
+    aliases = ['reannounce']
+
+    def handle(self, *args, **options):
+        self.console = component.get("ConsoleUI")
+        if len(args) == 0:
+            self.console.write(self.usage)
+            return
+        if len(args) > 0 and args[0].lower() == '*':
+            args = [""]
+            
+        torrent_ids = []
+        for arg in args:
+            torrent_ids.extend(self.console.match_torrent(arg))
+
+        client.core.force_reannounce(torrent_ids)
+
+    def complete(self, line):
+        # We use the ConsoleUI torrent tab complete method
+        return component.get("ConsoleUI").tab_complete_torrent(line)

--- a/scripts/install/deluge.sh
+++ b/scripts/install/deluge.sh
@@ -16,7 +16,7 @@
 function _deluge() {
   if [[ $deluge == repo ]]; then
     apt-get -q -y update >>"${OUTTO}" 2>&1
-    apt-get -q -y install deluged deluge-web >>"${OUTTO}" 2>&1
+    apt-get -q -y install deluged deluge-web deluge-console >>"${OUTTO}" 2>&1
     systemctl stop deluged
     update-rc.d deluged remove
     rm /etc/init.d/deluged

--- a/scripts/install/deluge.sh
+++ b/scripts/install/deluge.sh
@@ -17,6 +17,10 @@ function _deluge() {
   if [[ $deluge == repo ]]; then
     apt-get -q -y update >>"${OUTTO}" 2>&1
     apt-get -q -y install deluged deluge-web deluge-console >>"${OUTTO}" 2>&1
+    
+    chmod 644 ${local_packages}/deluge.UpdateTracker.py
+    cp ${local_packages}/deluge.UpdateTracker.py /usr/lib/python2.7/dist-packages/deluge/ui/console/commands/update-tracker.py
+    
     systemctl stop deluged
     update-rc.d deluged remove
     rm /etc/init.d/deluged
@@ -68,6 +72,10 @@ function _deluge() {
   python setup.py build >>"${OUTTO}" 2>&1
   python setup.py install --install-layout=deb >>"${OUTTO}" 2>&1
   python setup.py install_data >>"${OUTTO}" 2>&1
+
+  chmod 644 ${local_packages}/deluge.UpdateTracker.py
+  cp ${local_packages}/deluge.UpdateTracker.py $(find /usr/lib/python2.7/dist-packages/ -name 'deluge*.egg')"/deluge/ui/console/commands/update-tracker.py"
+
   cd ..
   rm -r {deluge,libtorrent}
 

--- a/scripts/remove/deluge.sh
+++ b/scripts/remove/deluge.sh
@@ -36,7 +36,7 @@ function _removeDeluge() {
   rm /etc/systemd/system/deluge-web@.service > /dev/null 2>&1
   rm -rf /usr/lib/python2.7/dist-packages/deluge*
   dpkg -r libtorrent
-  apt-get purge -y deluge > /dev/null 2>&1
+  apt-get purge -y deluge deluge-web deluge-console > /dev/null 2>&1
 
   sudo rm /install/.deluge.lock
   for u in ${users}; do

--- a/scripts/upgrade/deluge.sh
+++ b/scripts/upgrade/deluge.sh
@@ -5,7 +5,7 @@
 function _deluge() {
   if [[ $deluge == repo ]]; then
     apt-get -q -y update >>"${OUTTO}" 2>&1
-    apt-get -q -y install deluged deluge-web >>"${OUTTO}" 2>&1
+    apt-get -q -y install deluged deluge-web deluge-console >>"${OUTTO}" 2>&1
     systemctl stop deluged
     update-rc.d deluged remove
     rm /etc/init.d/deluged

--- a/scripts/upgrade/deluge.sh
+++ b/scripts/upgrade/deluge.sh
@@ -6,6 +6,10 @@ function _deluge() {
   if [[ $deluge == repo ]]; then
     apt-get -q -y update >>"${OUTTO}" 2>&1
     apt-get -q -y install deluged deluge-web deluge-console >>"${OUTTO}" 2>&1
+    
+    chmod 644 /etc/swizzin/scripts/deluge.UpdateTracker.py
+    cp /etc/swizzin/scripts/deluge.UpdateTracker.py /usr/lib/python2.7/dist-packages/deluge/ui/console/commands/update-tracker.py
+    
     systemctl stop deluged
     update-rc.d deluged remove
     rm /etc/init.d/deluged
@@ -57,6 +61,10 @@ function _deluge() {
   python setup.py build >>"${OUTTO}" 2>&1
   python setup.py install --install-layout=deb >>"${OUTTO}" 2>&1
   python setup.py install_data >>"${OUTTO}" 2>&1
+
+  chmod 644 /etc/swizzin/scripts/deluge.UpdateTracker.py
+  cp /etc/swizzin/scripts/deluge.UpdateTracker.py $(find /usr/lib/python2.7/dist-packages/ -name 'deluge*.egg')"/deluge/ui/console/commands/update-tracker.py"
+
   cd ..
   rm -r {deluge,libtorrent}
 


### PR DESCRIPTION
This PR adds the [update-tracker](https://github.com/s0undt3ch/Deluge/blob/master/deluge/ui/console/commands/update-tracker.py) command to Deluge regardless of Deluge installation type (repo, stable, or dev). The `update-tracker` comes in handy with problematic trackers to programmatically force-reannounces and avoid using pause/resume.

Furthremore, deluge-console was missing when installing Deluge from repo. This PR adds it. It also removes deluge-console if it was installed from repo.

(I am using nope@nope.com as e-mail for git, which I guess is the same for the poor danburg user.)