### PR TITLE
Fixes failure to create .deb for libtorrent

### DIFF
--- a/scripts/install/deluge.sh
+++ b/scripts/install/deluge.sh
@@ -61,6 +61,7 @@ function _deluge() {
   ./autotool.sh >>"${OUTTO}" 2>&1
   ./configure --enable-python-binding --with-lib-geoip --with-libiconv >>"${OUTTO}" 2>&1 >>"${OUTTO}" 2>&1
   make -j$(nproc) >>"${OUTTO}" 2>&1
+  mkdir -p /usr/local/include
   checkinstall -y --pkgversion=${LTRC} >>"${OUTTO}" 2>&1
   ldconfig
   cd ..


### PR DESCRIPTION
Recently,  libtorrent attempts to use the folder `/usr/local/include` when creating the package with checkinstall. The installation fails with 

```make[2]: Nothing to be done for 'install-exec-am'.
 /bin/mkdir -p '/usr/local/include/libtorrent'
/bin/mkdir: cannot create directory ‘/usr/local/include’: No such file or directory
Makefile:587: recipe for target 'install-nobase_includeHEADERS' failed
make[2]: *** [install-nobase_includeHEADERS] Error 1
make[2]: Leaving directory '/home/kaput/tmp/libtorrent/include/libtorrent'
Makefile:706: recipe for target 'install-am' failed
make[1]: *** [install-am] Error 2
make[1]: Leaving directory '/home/kaput/tmp/libtorrent/include/libtorrent'
Makefile:621: recipe for target 'install-recursive' failed
make: *** [install-recursive] Error 1

****  Installation failed. Aborting package creation.

Cleaning up...OK```

This mini patch creates `/usr/local/include` if it does not exist already