### PR TITLE
Add cronjob renewal to LE

### DIFF
--- a/scripts/install/letsencrypt.sh
+++ b/scripts/install/letsencrypt.sh
@@ -115,7 +115,7 @@ else
   fi
 fi
 
-/root/.acme.sh/acme.sh --install-cert -d ${hostname} --key-file /etc/nginx/ssl/${hostname}/key.pem --fullchain-file /etc/nginx/ssl/${hostname}/fullchain.pem --ca-file /etc/nginx/ssl/${hostname}/chain.pem --reloadcmd "service nginx force-reload"
+/root/.acme.sh/acme.sh --install-cert -d ${hostname} --key-file /etc/nginx/ssl/${hostname}/key.pem --fullchain-file /etc/nginx/ssl/${hostname}/fullchain.pem --ca-file /etc/nginx/ssl/${hostname}/chain.pem --reloadcmd "service nginx force-reload" --install-cronjob
 if [[ $main == yes ]]; then
   sed -i "s/ssl_certificate .*/ssl_certificate \/etc\/nginx\/ssl\/${hostname}\/fullchain.pem;/g" /etc/nginx/sites-enabled/default
   sed -i "s/ssl_certificate_key .*/ssl_certificate_key \/etc\/nginx\/ssl\/${hostname}\/key.pem;/g" /etc/nginx/sites-enabled/default


### PR DESCRIPTION
I believe this is all that is required. If we installed via `install`, cronjob would be added automatically, but since we use `install-cert` it is not.