### PR TITLE
Fix libtorrent lock file address 

### DIFF
--- a/scripts/install/deluge.sh
+++ b/scripts/install/deluge.sh
@@ -282,7 +282,7 @@ if [[ -n $noexec ]]; then
 	noexec=1
 fi
 
-if [[ ! -f /install/libtorrent.lock ]]; then
+if [[ ! -f /install/.libtorrent.lock ]]; then
   echo "Building libtorrent-rasterbar"; build_libtorrent_rasterbar
 fi
 


### PR DESCRIPTION
Deluge install is missing a . which causes libtorrent to be undefined if it was already installed.