### PR TITLE
Allow to override default torrent client config values for directories

### DIFF
--- a/scripts/install/deluge.sh
+++ b/scripts/install/deluge.sh
@@ -24,7 +24,6 @@ function _set_deluge_vars () {
 }
 
 function _dconf {
-  _set_deluge_vars
   for u in "${users[@]}"; do
     if [[ ${u} == ${master} ]]; then
       pass=$(cut -d: -f2 < /root/.master.info)
@@ -196,7 +195,6 @@ cat > /home/${u}/.config/deluge/hostlist.conf${SUFFIX} <<DHL
   ]
 }
 DHL
-  _set_deluge_vars
   echo "${u}:${pass}:10" > /home/${u}/.config/deluge/auth
   echo "localclient:${localpass}:10" >> /home/${u}/.config/deluge/auth
   chmod 600 /home/${u}/.config/deluge/auth
@@ -305,5 +303,6 @@ if [[ -n $noexec ]]; then
 fi
 
 echo "Configuring Deluge"
+_set_deluge_vars
 _dconf
 _dservice

--- a/scripts/install/deluge.sh
+++ b/scripts/install/deluge.sh
@@ -18,6 +18,7 @@ function _set_deluge_vars () {
 	#These paths are appended after "/home/${USER}/" in the config files. Notice the slashes.
   export complete_dir="Downloads"
   export watch_dir="dwatch"
+  export torrent_dir="dwatch"
   export download_dir="torrents/deluge"
   . /etc/swizzin/sources/functions/short
 	import_values_if_exists "/root/.config/delugecore.conf.defaults"
@@ -59,7 +60,7 @@ function _dconf {
     "ignore_limits_on_local_network": true,
     "rate_limit_ip_overhead": true,
     "daemon_port": ${DPORT},
-    "torrentfiles_location": "/home/${u}/${watch_dir}",
+    "torrentfiles_location": "/home/${u}/${torrent_dir}",
     "max_active_limit": -1,
     "geoip_db_location": "/usr/share/GeoIP/GeoIP.dat",
     "upnp": false,

--- a/scripts/install/deluge.sh
+++ b/scripts/install/deluge.sh
@@ -201,7 +201,7 @@ DHL
   echo "localclient:${localpass}:10" >> /home/${u}/.config/deluge/auth
   chmod 600 /home/${u}/.config/deluge/auth
   chown -R ${u}.${u} /home/${u}/.config/
-  mkdir "/home/${u}/${watch_dir}"
+  mkdir -p "/home/${u}/${watch_dir}"
   chown ${u}: "/home/${u}/${watch_dir}"
   mkdir -p "/home/${u}/$download_dir"
   chown ${u}: "/home/${u}/${download_dir}"

--- a/scripts/install/deluge.sh
+++ b/scripts/install/deluge.sh
@@ -16,15 +16,11 @@
 function _set_deluge_vars () {
   #If you found this code, this is an unsupported feature introduced by community.
 	#These paths are appended after "/home/${USER}/" in the config files. Notice the slashes.
-  config_file="/root/.config/delugecore.conf.defaults"
   export complete_dir="Downloads"
   export watch_dir="dwatch"
   export download_dir="torrents/deluge"
-	if [[ -f ${config_file} ]]; then 
- 		echo "Found ${confid_file}, importing values"
-		. "${config_file}"
-		export $(cut -d= -f1 ${config_file})
-	fi
+  . /etc/swizzin/sources/functions/short
+	import_values_if_exists "/root/.config/delugecore.conf.defaults"
 }
 
 function _dconf {

--- a/scripts/install/deluge.sh
+++ b/scripts/install/deluge.sh
@@ -13,7 +13,19 @@
 #
 #################################################################################
 
+function _set_deluge_vars () {
+  config_file="/root/.config/delugecore.conf.defaults"
+  export complete_dir="Downloads"
+  export watch_dir="dwatch"
+  export download_dir="torrents/deluge"
+	if [[ -f ${config_file} ]]; then 
+		. "${config_file}"
+		export $(cut -d= -f1 ${config_file})
+	fi
+}
+
 function _dconf {
+  _set_deluge_vars
   for u in "${users[@]}"; do
     if [[ ${u} == ${master} ]]; then
       pass=$(cut -d: -f2 < /root/.master.info)
@@ -42,14 +54,14 @@ function _dconf {
     "max_download_speed": -1.0,
     "send_info": false,
     "natpmp": true,
-    "move_completed_path": "/home/${u}/Downloads",
+    "move_completed_path": "/home/${u}/${complete_dir}",
     "peer_tos": "0x08",
     "enc_in_policy": 1,
     "queue_new_to_top": false,
     "ignore_limits_on_local_network": true,
     "rate_limit_ip_overhead": true,
     "daemon_port": ${DPORT},
-    "torrentfiles_location": "/home/${u}/dwatch",
+    "torrentfiles_location": "/home/${u}/${watch_dir}",
     "max_active_limit": -1,
     "geoip_db_location": "/usr/share/GeoIP/GeoIP.dat",
     "upnp": false,
@@ -65,7 +77,7 @@ function _dconf {
       "ltConfig"
     ],
     "max_half_open_connections": 50,
-    "download_location": "/home/${u}/torrents/deluge",
+    "download_location": "/home/${u}/${download_dir}",
     "compact_allocation": true,
     "max_upload_speed": -1.0,
     "plugins_location": "/home/${u}/.config/deluge/plugins",
@@ -128,7 +140,7 @@ function _dconf {
     "enc_out_policy": 1,
     "seed_time_ratio_limit": 7.0,
     "remove_seed_at_ratio": false,
-    "autoadd_location": "/home/${u}/dwatch/",
+    "autoadd_location": "/home/${u}/${watch_dir}/",
     "max_upload_slots_global": -1,
     "seed_time_limit": 180,
     "cache_size": 512,
@@ -190,10 +202,10 @@ DHL
   echo "localclient:${localpass}:10" >> /home/${u}/.config/deluge/auth
   chmod 600 /home/${u}/.config/deluge/auth
   chown -R ${u}.${u} /home/${u}/.config/
-  mkdir /home/${u}/dwatch
-  chown ${u}: /home/${u}/dwatch
-  mkdir -p /home/${u}/torrents/deluge
-  chown ${u}: /home/${u}/torrents/deluge
+  mkdir "/home/${u}/${watch_dir}"
+  chown ${u}: "/home/${u}/${watch_dir}"
+  mkdir -p "/home/${u}/$download_dir"
+  chown ${u}: "/home/${u}/${download_dir}"
 done
 }
 function _dservice {

--- a/scripts/install/deluge.sh
+++ b/scripts/install/deluge.sh
@@ -14,11 +14,14 @@
 #################################################################################
 
 function _set_deluge_vars () {
+  #If you found this code, this is an unsupported feature introduced by community.
+	#These paths are appended after "/home/${USER}/" in the config files. Notice the slashes.
   config_file="/root/.config/delugecore.conf.defaults"
   export complete_dir="Downloads"
   export watch_dir="dwatch"
   export download_dir="torrents/deluge"
 	if [[ -f ${config_file} ]]; then 
+ 		echo "Found ${confid_file}, importing values"
 		. "${config_file}"
 		export $(cut -d= -f1 ${config_file})
 	fi
@@ -197,7 +200,7 @@ cat > /home/${u}/.config/deluge/hostlist.conf${SUFFIX} <<DHL
   ]
 }
 DHL
-
+  _set_deluge_vars
   echo "${u}:${pass}:10" > /home/${u}/.config/deluge/auth
   echo "localclient:${localpass}:10" >> /home/${u}/.config/deluge/auth
   chmod 600 /home/${u}/.config/deluge/auth
@@ -208,6 +211,7 @@ DHL
   chown ${u}: "/home/${u}/${download_dir}"
 done
 }
+
 function _dservice {
   if [[ ! -f /etc/systemd/system/deluged@.service ]]; then
   dvermajor=$(deluged -v | grep deluged | grep -oP '\d+\.\d+\.\d+' | cut -d. -f1)

--- a/scripts/install/rtorrent.sh
+++ b/scripts/install/rtorrent.sh
@@ -11,6 +11,16 @@
 #
 function _string() { perl -le 'print map {(a..z,A..Z,0..9)[rand 62] } 0..pop' 15 ; }
 
+function _set_rt_vars() {
+	#If you found this code, this is an unsupported feature introduced by community.
+	#These paths are appended after "/home/${USER}/" in the config files. Notice the slashes.
+	export download_dir="torrents/rtorrent"
+	export session_dir=".sessions"
+	export default_watch_dir="rwatch"
+	. /etc/swizzin/sources/functions/short
+	import_values_if_exists "/root/.config/rtorrent.rc.defaults"
+}
+
 function _makedirs() {
 	mkdir -p /home/${user}/${download_dir} 2>> $log
 	mkdir -p /home/${user}/${session_dir}
@@ -53,15 +63,7 @@ EOF
 chown ${user}.${user} /home/${user}/.rtorrent.rc
 }
 
-function _set_rt_vars() {
-	#If you found this code, this is an unsupported feature introduced by community.
-	#These paths are appended after "/home/${USER}/" in the config files. Notice the slashes.
-	export download_dir="torrents/rtorrent"
-	export session_dir=".sessions"
-	export default_watch_dir="rwatch"
-	. /etc/swizzin/sources/functions/short
-	import_values_if_exists "/root/.config/rtorrent.rc.defaults"
-}
+
 
 _systemd() {
 cat >/etc/systemd/system/rtorrent@.service<<EOF

--- a/scripts/install/rtorrent.sh
+++ b/scripts/install/rtorrent.sh
@@ -56,11 +56,14 @@ chown ${user}.${user} /home/${user}/.rtorrent.rc
 }
 
 function _set_rt_vars() {
+	#If you found this code, this is an unsupported feature introduced by community.
+	#These paths are appended after "/home/${USER}/" in the config files. Notice the slashes.
 	config_file="/root/.config/rtorrent.rc.defaults"
 	export download_dir="torrents/rtorrent"
 	export session_dir=".sessions"
 	export default_watch_dir="rwatch"
-	if [[ -f ${config_file} ]]; then 
+	if [[ -f ${config_file} ]]; then
+		echo "Found ${confid_file}, importing values"
 		. "${config_file}"
 		export $(cut -d= -f1 ${config_file})
 	fi

--- a/scripts/install/rtorrent.sh
+++ b/scripts/install/rtorrent.sh
@@ -58,15 +58,11 @@ chown ${user}.${user} /home/${user}/.rtorrent.rc
 function _set_rt_vars() {
 	#If you found this code, this is an unsupported feature introduced by community.
 	#These paths are appended after "/home/${USER}/" in the config files. Notice the slashes.
-	config_file="/root/.config/rtorrent.rc.defaults"
 	export download_dir="torrents/rtorrent"
 	export session_dir=".sessions"
 	export default_watch_dir="rwatch"
-	if [[ -f ${config_file} ]]; then
-		echo "Found ${confid_file}, importing values"
-		. "${config_file}"
-		export $(cut -d= -f1 ${config_file})
-	fi
+	. /etc/swizzin/sources/functions/short
+	import_values_if_exists "/root/.config/rtorrent.rc.defaults"
 }
 
 _systemd() {

--- a/scripts/install/rtorrent.sh
+++ b/scripts/install/rtorrent.sh
@@ -12,7 +12,6 @@
 function _string() { perl -le 'print map {(a..z,A..Z,0..9)[rand 62] } 0..pop' 15 ; }
 
 function _makedirs() {
-	_set_rt_vars
 	mkdir -p /home/${user}/${download_dir} 2>> $log
 	mkdir -p /home/${user}/${session_dir}
 	mkdir -p /home/${user}/${default_watch_dir}
@@ -22,7 +21,6 @@ function _makedirs() {
 }
 
 function _rconf() {
-	_set_rt_vars
 cat >/home/${user}/.rtorrent.rc<<EOF
 # -- START HERE --
 directory.default.set = /home/${user}/${download_dir}
@@ -105,6 +103,7 @@ portend=$((${port} + 1500))
 
 if [[ -n $1 ]]; then
 	user=$1
+	_set_rt_vars
 	_makedirs
 	_rconf
 	exit 0

--- a/sources/functions/short
+++ b/sources/functions/short
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+#please make sure to give this full paths
+function rm_if_exists () {
+    path="$1"
+    if [[ -e "$path" ]]; then
+      rm -rf "$path"
+    fi
+}
+
+#Imports and exports values from a file if the file exists.
+function import_values_if_exists () {
+    config_file="$1"
+	if [[ -f "${config_file}" ]]; then
+		echo "Found ${confid_file}, importing values"
+		. "${config_file}"
+		export $(cut -d= -f1 "${config_file}")
+	fi
+}
+

--- a/sources/functions/short
+++ b/sources/functions/short
@@ -4,7 +4,7 @@
 function import_values_if_exists () {
     config_file="$1"
 	if [[ -f "${config_file}" ]]; then
-		echo "Found ${confid_file}, importing values"
+		echo "Found ${config_file}, importing values"
 		. "${config_file}"
 		export $(cut -d= -f1 "${config_file}")
 	fi

--- a/sources/functions/short
+++ b/sources/functions/short
@@ -1,13 +1,5 @@
 #!/bin/bash
 
-#please make sure to give this full paths
-function rm_if_exists () {
-    path="$1"
-    if [[ -e "$path" ]]; then
-      rm -rf "$path"
-    fi
-}
-
 #Imports and exports values from a file if the file exists.
 function import_values_if_exists () {
     config_file="$1"


### PR DESCRIPTION
I am personally not a big fan of the enforced folder structure introduced by the scripts, and so I'd like to open possibilities for admins who create their users to override these without having to go and change something every time.

This will also make the configs' paths and directory creation easier to maintain as the default directory names are in one place, and so don't need to be cross-referenced and find&replaced.

If a user wants to change only one variable, they don't need to declare the others. If the file doesn't exist, no one notices and the result is the same.

I've gone ahead and mentioned this is unsupported in the code, but I'm more than happy to append the docs with this and check the issues for this ;)

If there's anything else we'd want to expose to the user, as a "`skel`-able" variable, this would be an optional path to pursue further.