### PR TITLE
Setdisk++

### DIFF
--- a/scripts/box
+++ b/scripts/box
@@ -242,6 +242,10 @@ function _adduser {
   htpasswd -b -c /etc/htpasswd.d/htpasswd.${user} $user $pass
   chmod 750 /home/${user}
 
+  if [[ -f /install/.quota.lock ]]; then 
+    setdisk "$user"
+  fi
+
   if [[ -f /install/.panel.lock ]]; then setfacl -m g:swizzin:rx /home/${user}; fi
   echo "D /var/run/${user} 0750 ${user} ${user} -" >> /etc/tmpfiles.d/${user}.conf
   systemd-tmpfiles /etc/tmpfiles.d/${user}.conf --create

--- a/scripts/setdisk
+++ b/scripts/setdisk
@@ -1,54 +1,81 @@
 #!/bin/bash
-#
-# [QuickBox Quota Set Script]
+# Swizzin Quota Set Script
+# Modified by flying_sausages from Quickbox files
 #
 # GitHub:   https://github.com/QuickBox/quickbox_packages
-# Author:   QuickBox.io
-# URL:      https://plaza.quickbox.io
-#
 # QuickBox Copyright (C) 2017 QuickBox.io
 # Licensed under GNU General Public License v3.0 GPL-3 (in short)
-#
-#   You may copy, distribute and modify the software as long as you track
-#   changes/dates in source files. Any modifications to our software
-#   including (via compiler) GPL-licensed code must also be made available
-#   under the GPL along with build & install instructions.
-#
+
 
 function _setdisk() {
-echo "================================================================================="
-echo "Disk Space MUST be in GB/TB - Do not attempt to add decimals in space settings,"
-echo "Example - Good: 711GB OR 2TB, Example - Bad: 711.5GB OR 2.5TB"
-echo "================================================================================="
-echo
-echo -n "Username: "
-read username
-echo "Quota size for user: (EX: 500GB): "
-read SIZE
-case $SIZE in
+username="$1"
+SIZE="$2"
+if [[ -z $1 ]]; then 
+  echo "======================================================================================"
+  echo "Disk Space MUST be in GB/TB or max - Do not attempt to add decimals in space settings,"
+  echo "Example - Good: 711GB, 2TB, or max"
+  echo "Example - Bad: 711.5GB, 2.5TB, or MAX"
+  echo "You can also use $0 username size to set the values non-interactively"
+  echo "Example - $0 myuser 20GB"
+  echo "======================================================================================"
+  echo
+fi
+if [[ -z $username ]]; then
+    echo -n "Username: "
+    read -r username
+  else 
+    if [[ ! $(id -u "$username") ]]; then
+      echo "User does not exist. Exiting"
+      exit 1
+    fi
+fi
+if [[ -z "$SIZE" ]]; then
+  echo "Quota size for user: (EX: 500GB, 2TB, max): "
+  read -r SIZE
+fi
+case "$SIZE" in
+  max)
+    fstabid=$(grep quota /etc/fstab | awk '{printf $1}')
+    if [[ $fstabid =~ "UUID" ]]; then
+      uuid=$(echo "$fstabid" | cut -d= -f 2)
+      disk=$(blkid -U "$uuid")
+    else
+      disk=$fstabid
+    fi
+    onekblocks=$(df | grep "$disk" | awk '{print $2}')
+    humansize=$(df | grep "$disk" | awk '{print $2}')
+    echo "Maximum on $disk is $onekblocks (approx $humansize)"
+
+    setquota -u "${username}" "$onekblocks" "$onekblocks" 0 0 -a
+  ;;
   *TB)
-    QUOTASIZE=$(echo $SIZE|cut -d'T' -f1)
-    DISKSIZE=$(($QUOTASIZE * 1024 * 1024 * 1024))
-    setquota -u ${username} ${DISKSIZE} ${DISKSIZE} 0 0 -a
+    QUOTASIZE=$(echo "$SIZE"|cut -d'T' -f1)
+    DISKSIZE=$((QUOTASIZE * 1024 * 1024 * 1024))
+    setquota -u "${username}" "${DISKSIZE}" "${DISKSIZE}" 0 0 -a
   ;;
   *GB)
-    QUOTASIZE=$(echo $SIZE|cut -d'G' -f1)
-    DISKSIZE=$(($QUOTASIZE * 1024 * 1024))
-    setquota -u ${username} ${DISKSIZE} ${DISKSIZE} 0 0 -a
+    QUOTASIZE=$(echo "$SIZE"|cut -d'G' -f1)
+    DISKSIZE=$((QUOTASIZE * 1024 * 1024))
+    setquota -u "${username}" "${DISKSIZE}" "${DISKSIZE}" 0 0 -a
   ;;
   *MB)
-    QUOTASIZE=$(echo $SIZE|cut -d'M' -f1)
-                DISKSIZE=$(($QUOTASIZE * 1024))
-                setquota -u ${username} ${DISKSIZE} ${DISKSIZE} 0 0 -a
+    QUOTASIZE=$(echo "$SIZE"|cut -d'M' -f1)
+                DISKSIZE=$((QUOTASIZE * 1024))
+                setquota -u "${username}" "${DISKSIZE}" "${DISKSIZE}" 0 0 -a
   ;;
   *)
-    echo "================================================================================="
-    echo "Disk Space MUST be in GB/TB - Do not attempt to add deciamals in space settings,"
+    echo "======================================================================================"
+    echo "Disk Space MUST be in GB/TB or max- Do not attempt to add deciamals in space settings,"
     echo "Example - Good: 711GB OR 2TB, Example - Bad: 711.5GB OR 2.5TB"
     echo "Exiting script, type bash $0 and try again"
-    echo "=================================================================================";exit 0
+    echo "======================================================================================";exit 1
   ;;
 esac
 }
 
-_setdisk
+if [[ -f /install/.quota.lock ]]; then
+  _setdisk "$1" "$2"
+else
+  echo "Quota not installed"
+  exit 1
+fi

--- a/scripts/setdisk
+++ b/scripts/setdisk
@@ -39,14 +39,18 @@ case "$SIZE" in
     if [[ $fstabid =~ "UUID" ]]; then
       uuid=$(echo "$fstabid" | cut -d= -f 2)
       disk=$(blkid -U "$uuid")
+    elif [[ $fstabid =~ "LABEL" ]]; then
+      label=$(echo "$fstabid" | cut -d= -f 2)
+      disk=$(blkid -L "$label")
     else
       disk=$fstabid
     fi
-    onekblocks=$(df | grep "$disk" | awk '{print $2}')
-    humansize=$(df | grep "$disk" | awk '{print $2}')
+
+    onekblocks=$(df $disk --output=source,size | tail -1 | awk '{printf $2}')
+    humansize=$(df $disk -h --output=source,size | tail -1 | awk '{printf $2}')
     echo "Maximum on $disk is $onekblocks (approx $humansize)"
 
-    setquota -u "${username}" "$onekblocks" "$onekblocks" 0 0 -a
+    # setquota -u "${username}" "$onekblocks" "$onekblocks" 0 0 -a
   ;;
   *TB)
     QUOTASIZE=$(echo "$SIZE"|cut -d'T' -f1)

--- a/scripts/setdisk
+++ b/scripts/setdisk
@@ -12,8 +12,8 @@ username="$1"
 SIZE="$2"
 if [[ -z $1 ]]; then 
   echo "======================================================================================"
-  echo "Disk Space MUST be in GB/TB or max - Do not attempt to add decimals in space settings,"
-  echo "Example - Good: 711GB, 2TB, or max"
+  echo "Disk Space MUST be in MB/GB/TB or max - Do not attempt to add decimals in space settings,"
+  echo "Example - Good: 711GB, 2TB,, or max"
   echo "Example - Bad: 711.5GB, 2.5TB, or MAX"
   echo "You can also use setdisk username size to set the values non-interactively"
   echo "Example - 'setdisk myuser 20GB'"
@@ -33,6 +33,16 @@ if [[ -z "$SIZE" ]]; then
   echo "Quota size for user: (EX: 500GB, 2TB, max): "
   read -r SIZE
 fi
+
+if [[ $SIZE = 'max' ]]; then 
+  echo "Using max size. Please notice this is more than what is actually available on the disk."
+elif echo "$SIZE" | grep -q -E '^[0-9]+(M|T|G)B$'; then
+  # echo "Using $SIZE" 
+  :
+else
+  SIZE='Invalid'
+fi
+
 case "$SIZE" in
   max)
     fstabid=$(grep quota /etc/fstab | awk '{printf $1}')
@@ -68,10 +78,10 @@ case "$SIZE" in
                 setquota -u "${username}" "${DISKSIZE}" "${DISKSIZE}" 0 0 -a
   ;;
   *)
-    echo "============================================================="
-    echo "QUOTA ERROR Size MUST be in either 'max' or integer of GB/TB."
-    echo "Type 'setdisk $*' and try again"
-    echo "=============================================================";return 1
+    echo "================================================================"
+    echo "QUOTA ERROR Size MUST be in either 'max' or integer of MB/GB/TB."
+    echo "Type 'setdisk $1' and try again"
+    echo "================================================================";return 1
   ;;
 esac
 }

--- a/scripts/setdisk
+++ b/scripts/setdisk
@@ -15,8 +15,8 @@ if [[ -z $1 ]]; then
   echo "Disk Space MUST be in GB/TB or max - Do not attempt to add decimals in space settings,"
   echo "Example - Good: 711GB, 2TB, or max"
   echo "Example - Bad: 711.5GB, 2.5TB, or MAX"
-  echo "You can also use $0 username size to set the values non-interactively"
-  echo "Example - $0 myuser 20GB"
+  echo "You can also use setdisk username size to set the values non-interactively"
+  echo "Example - 'setdisk myuser 20GB'"
   echo "======================================================================================"
   echo
 fi
@@ -26,7 +26,7 @@ if [[ -z $username ]]; then
   else 
     if [[ ! $(id -u "$username") ]]; then
       echo "User does not exist. Exiting"
-      exit 1
+      return 1
     fi
 fi
 if [[ -z "$SIZE" ]]; then
@@ -46,8 +46,8 @@ case "$SIZE" in
       disk=$fstabid
     fi
 
-    onekblocks=$(df $disk --output=source,size | tail -1 | awk '{printf $2}')
-    humansize=$(df $disk -h --output=source,size | tail -1 | awk '{printf $2}')
+    onekblocks=$(df "$disk" --output=source,size | tail -1 | awk '{printf $2}')
+    humansize=$(df "$disk" -h --output=source,size | tail -1 | awk '{printf $2}')
     echo "Maximum on $disk is $onekblocks (approx $humansize)"
 
     # setquota -u "${username}" "$onekblocks" "$onekblocks" 0 0 -a
@@ -68,11 +68,10 @@ case "$SIZE" in
                 setquota -u "${username}" "${DISKSIZE}" "${DISKSIZE}" 0 0 -a
   ;;
   *)
-    echo "======================================================================================"
-    echo "Disk Space MUST be in GB/TB or max- Do not attempt to add deciamals in space settings,"
-    echo "Example - Good: 711GB OR 2TB, Example - Bad: 711.5GB OR 2.5TB"
-    echo "Exiting script, type bash $0 and try again"
-    echo "======================================================================================";exit 1
+    echo "============================================================="
+    echo "QUOTA ERROR Size MUST be in either 'max' or integer of GB/TB."
+    echo "Type 'setdisk $*' and try again"
+    echo "=============================================================";return 1
   ;;
 esac
 }
@@ -81,5 +80,5 @@ if [[ -f /install/.quota.lock ]]; then
   _setdisk "$1" "$2"
 else
   echo "Quota not installed"
-  exit 1
+  return 1
 fi

--- a/sources/functions/transmission
+++ b/sources/functions/transmission
@@ -11,7 +11,7 @@ function _get_next_port_from_json () {
     for d in /home/*/; do
         confpath="${d}${relpath}"
         if [[ -f $confpath ]];then 
-            value=$(grep "$key" "$confpath" | tr -d -c 0-9)
+            value=$(grep \""$key"\" "$confpath" | tr -d -c 0-9)
         fi
         if [[ -n $value ]]; then
             if [[ $value -ge $highestvalue ]]; then


### PR DESCRIPTION
This introduces the following:
- passing arguments to setdisk to skip the `read` stuff if possible
- allowing use of `max` to give all space possible (to be used by server admins who don't want to see rutorrent bugs if no quota is set (Maybe that should be fixed too) )
- Add `setdisk` to the adduser procedure