### PR TITLE
Fix letsencrypt failure if Cloudflare domain is on allowed TLD but has substring of a prohibited TLD

### DIFF
--- a/scripts/install/letsencrypt.sh
+++ b/scripts/install/letsencrypt.sh
@@ -49,7 +49,7 @@ esac
 
 if [[ ${cf} == yes ]]; then
 
-  if [[ $hostname =~ (.cf|.ga|.gq|.ml|.tk) ]]; then 
+  if [[ $hostname =~ (\.cf$|\.ga$|\.gq$|\.ml$|\.tk$) ]]; then
     echo "ERROR Cloudflare does not support API calls for the following TLDs: cf, .ga, .gq, .ml, or .tk"
     exit 1
   fi


### PR DESCRIPTION
The current regex used to prohibit TLDs that Cloudflare doesn't support is wrong, it should look for Anything.ProhibitedTLD but instead it looks for AnythingProhibitedTLDAnything. 

For example, the domain "the-abbreviation-for-the-state-of-georgia-is-ga.com" will be rejected because it contains some characters, followed by "ga" (a prohibited TLD), followed by some characters.

This change ensures that the regex only matches against a literal period, then a prohibited TLD, then the end of the hostname.