### PR TITLE
Make sure held packages are removed

### DIFF
--- a/sources/functions/rtorrent
+++ b/sources/functions/rtorrent
@@ -200,7 +200,7 @@ function remove_rtorrent () {
     toclean+=($repo)
   fi
   for c in ${toclean[@]}; do
-    apt-get remove -y -q $c >> $log 2>&1
+    apt-get remove -y -q --allow-change-held-packages $c >> $log 2>&1
   done
 }
 


### PR DESCRIPTION
Should resolve the following issues found in end-user's log
```
user@host:~$ sudo cat /root/logs/swizzin.log
Reading package lists...
Building dependency tree...
Reading state information...
The following packages will be REMOVED:
  rtorrent
The following held packages will be changed:
  rtorrent
0 upgraded, 0 newly installed, 1 to remove and 0 not upgraded.
E: Held packages were changed and -y was used without --allow-change-held-packages.
```