### PR TITLE
Clarify master user dialogues in setup, adjust whiptail sizes

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -104,12 +104,12 @@ function _nukeovh() {
 }
 
 function _intro() {
-  whiptail --title "Swizzin seedbox installer" --msgbox "Yo, what's up? Let's install this swiz." 15 50
+  whiptail --title "Swizzin seedbox installer" --msgbox "Yo, what's up? Let's install this swiz." 7 43
 }
 
 function _adduser() {
   while [[ -z $user ]]; do
-    user=$(whiptail --inputbox "Enter username for Swizzin \"master\"" 9 40 3>&1 1>&2 2>&3); exitstatus=$?; if [ "$exitstatus" = 1 ]; then exit 0; fi
+    user=$(whiptail --inputbox "Enter username for Swizzin \"master\"" 8 40 3>&1 1>&2 2>&3); exitstatus=$?; if [ "$exitstatus" = 1 ]; then exit 0; fi
     if [[ $user =~ [A-Z] ]]; then
       read -n 1 -s -r -p "Usernames must not contain capital letters. Press enter to try again."
       printf "\n"

--- a/setup.sh
+++ b/setup.sh
@@ -109,7 +109,7 @@ function _intro() {
 
 function _adduser() {
   while [[ -z $user ]]; do
-    user=$(whiptail --inputbox "Enter username for Swizzin \"master\"" 9 30 3>&1 1>&2 2>&3); exitstatus=$?; if [ "$exitstatus" = 1 ]; then exit 0; fi
+    user=$(whiptail --inputbox "Enter username for Swizzin \"master\"" 9 40 3>&1 1>&2 2>&3); exitstatus=$?; if [ "$exitstatus" = 1 ]; then exit 0; fi
     if [[ $user =~ [A-Z] ]]; then
       read -n 1 -s -r -p "Usernames must not contain capital letters. Press enter to try again."
       printf "\n"
@@ -117,7 +117,7 @@ function _adduser() {
     fi
   done
   while [[ -z "${pass}" ]]; do
-    pass=$(whiptail --inputbox "Enter new password for $user. Leave empty to generate." 9 30 3>&1 1>&2 2>&3); exitstatus=$?; if [ "$exitstatus" = 1 ]; then exit 0; fi
+    pass=$(whiptail --inputbox "Enter new password for $user. Leave empty to generate." 9 40 3>&1 1>&2 2>&3); exitstatus=$?; if [ "$exitstatus" = 1 ]; then exit 0; fi
     if [[ -z "${pass}" ]]; then
       pass="$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c16)"
     fi

--- a/setup.sh
+++ b/setup.sh
@@ -117,7 +117,7 @@ function _adduser() {
     fi
   done
   while [[ -z "${pass}" ]]; do
-    pass=$(whiptail --inputbox "Enter User password. Leave empty to generate." 9 30 3>&1 1>&2 2>&3); exitstatus=$?; if [ "$exitstatus" = 1 ]; then exit 0; fi
+    pass=$(whiptail --inputbox "Enter new password for $user. Leave empty to generate." 9 30 3>&1 1>&2 2>&3); exitstatus=$?; if [ "$exitstatus" = 1 ]; then exit 0; fi
     if [[ -z "${pass}" ]]; then
       pass="$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c16)"
     fi

--- a/setup.sh
+++ b/setup.sh
@@ -109,7 +109,7 @@ function _intro() {
 
 function _adduser() {
   while [[ -z $user ]]; do
-    user=$(whiptail --inputbox "Enter Username" 9 30 3>&1 1>&2 2>&3); exitstatus=$?; if [ "$exitstatus" = 1 ]; then exit 0; fi
+    user=$(whiptail --inputbox "Enter username for Swizzin \"master\"" 9 30 3>&1 1>&2 2>&3); exitstatus=$?; if [ "$exitstatus" = 1 ]; then exit 0; fi
     if [[ $user =~ [A-Z] ]]; then
       read -n 1 -s -r -p "Usernames must not contain capital letters. Press enter to try again."
       printf "\n"


### PR DESCRIPTION
Just to make sure users know what "master" means and that they will change their password if they are re-using an existing account.

![image](https://user-images.githubusercontent.com/23618693/84556704-3d752b80-ad1c-11ea-8a88-5e8d02f33113.png)

Notice `Swizzin "master"`
![image](https://user-images.githubusercontent.com/23618693/84556672-e96a4700-ad1b-11ea-94c2-ed897d2ebb61.png)

Notice `new password for $user`
![image](https://user-images.githubusercontent.com/23618693/84556676-f25b1880-ad1b-11ea-8c6b-14d4035b46d3.png)
