### PR TITLE
HOTFIX znc focal ppa

### DIFF
--- a/scripts/install/znc.sh
+++ b/scripts/install/znc.sh
@@ -32,10 +32,11 @@ if [[ $DISTRO == Debian ]]; then
   . /etc/swizzin/sources/functions/backports
   check_debian_backports
   set_packages_to_backports znc
-elif [[ $DISTRO == Ubuntu ]]; then
-  add-apt-repository --yes ppa:teward/znc >> ${OUTTO} 2>&1
-fi
   apt_update
+elif [[ $CODENAME =~ ("xenial"|"bionic") ]]; then
+  add-apt-repository --yes ppa:teward/znc >> ${OUTTO} 2>&1
+  apt_update
+fi
   apt_install znc
   #sudo -u znc crontab -l | echo -e "*/10 * * * * /usr/bin/znc >/dev/null 2>&1\n@reboot /usr/bin/znc >/dev/null 2>&1" | crontab -u znc - > /dev/null 2>&1
   cat > /etc/systemd/system/znc.service <<ZNC
@@ -59,7 +60,9 @@ killall -u znc znc > /dev/null 2>&1
 sleep 1
 
 # Check for LE cert, and copy it if available.
-le_znc_hook
+if [[ -f /install/nginx.lock ]]; then 
+  le_znc_hook
+fi
 
 systemctl start znc
 echo "$(grep Port /home/znc/.znc/configs/znc.conf | sed -e 's/^[ \t]*//')" > /install/.znc.lock


### PR DESCRIPTION
No ZNC ppa for focal so we fall back to 1.7.5 which is in apt.

The le hook thing needs nginx to begin with so check for at least that, otherwise it will always run with or without letsencrypt